### PR TITLE
Update Makefile with current URL for sounds

### DIFF
--- a/asterisk/sounds/Makefile
+++ b/asterisk/sounds/Makefile
@@ -23,7 +23,7 @@ MOH_DIR:=$(DESTDIR)$(ASTDATADIR)/moh
 ASL_DIR:=$(DESTDIR)$(ASTDATADIR)/sounds/rpt
 CORE_SOUNDS_VERSION:=1.4.9
 EXTRA_SOUNDS_VERSION:=1.4.8
-SOUNDS_URL:=http://downloads.digium.com/pub/telephony/sounds/releases
+SOUNDS_URL:=http://downloads.asterisk.org/pub/telephony/sounds/releases
 ASL_SOUNDS_URL:=http://dvswitch.org/files/AllStarLink
 
 MCS:=$(subst -EN-,-en-,$(MENUSELECT_CORE_SOUNDS))


### PR DESCRIPTION
The Asterisk sounds repository has moved to http://downloads.asterisk.org.  This causes the build to fail, because when the script attempts to download the sounds archive, it gets a 302 HTTP redirect and downloads a HTML listing of the repo directory instead.

This PR provides the correct URL in SOUNDS_URL in the Makefile.